### PR TITLE
Enable terminal width detection to improve output readability

### DIFF
--- a/IzVerifier/logging/reporter.py
+++ b/IzVerifier/logging/reporter.py
@@ -1,5 +1,6 @@
 __author__ = 'fcanas'
 
+import termhelper
 
 class Reporter:
     """
@@ -7,12 +8,12 @@ class Reporter:
     """
 
     def __init__(self):
-        pass
+        self.width = 80  # default width of terminal
 
     templates = {
-        'test': '[ {0:.<40}{1:.>40} ]',
-        'set_tuples': '{0:.<40}{1:.>40}',
-        'set_items': '{0:.<80}'
+        'test': '[ {0:.<{2}}{1:.>{3}} ]',
+        'set_tuples': '{0:.<{2}}{1:.>{3}}',
+        'set_items': '{0:.<{1}}'
     }
 
     def report_test(self, test, items):
@@ -20,7 +21,8 @@ class Reporter:
         Report header for specification results.
         """
         template = self.templates['test']
-        print template.format(test, len(items))
+        test_width = self.width - 4  # Test tuple is wrapped in [  ], which is 4 characters
+        print template.format(test, len(items), 0, test_width - len(test), len(test))
         self.report_set(items)
 
     def report_set(self, entities):
@@ -30,11 +32,44 @@ class Reporter:
         for item in sorted(entities):
             if type(item) is tuple:
                 template = self.templates['set_tuples']
-                print template.format(item[0], item[1])
+                tuple_padding = self.get_tuple_padding(item)
+                print template.format(item[0], item[1], tuple_padding, len(item[1]))
             else:
                 template = self.templates['set_items']
-                print template.format(item)
+                print template.format(item, self.width)
 
+    def set_terminal_width(self):
+        """
+        Overwrites default terminal width with the width of the current terminal window.
+        """
+
+        height, width = termhelper.terminal_height_width()
+        self.width = width
+
+    def get_tuple_padding(self, item):
+        """
+        Returns the proper length of padding for a tuple.
+        The first item is allocated at least 30 characters of space.
+        The second item is allocated up to 50 characters.
+        """
+
+        # Default padding, used when both items fit in their own allocated space without shifting the padding
+        # and when a line break is unavoidable (default padding keeps the output more readable than no padding
+        # in the case of a very short first item with a very long second item)
+        tuple_padding = max(30, self.width - 50)
+
+        # If the combined length of the items is short enough to fit on one line, avoid a line break
+        if len(item[0]) + len(item[1]) < self.width:
+
+            # If the first item fills up its allocated space, pad by 1 character
+            if len(item[0]) >= max(30, self.width - 50):
+                tuple_padding = len(item[0]) + 1
+
+            # If the second item is longer than its allocated space, shorten the padding to avoid a line break
+            elif len(item[1]) > min(self.width - 30, 50):
+                tuple_padding = self.width - len(item[1])
+
+        return tuple_padding
 
 def display_paths(paths):
     """

--- a/IzVerifier/logging/termhelper.py
+++ b/IzVerifier/logging/termhelper.py
@@ -1,0 +1,19 @@
+import sys
+import fcntl
+import termios
+import struct
+
+def terminal_height_width():
+    """
+    Attempt to determine size of terminal window, and set to 25x80 if an exception is thrown.
+    """
+    try:
+        height, width = struct.unpack('hh',  fcntl.ioctl(sys.stdout, termios.TIOCGWINSZ, '1234'))
+    except IOError:
+        height, width = 25, 80
+
+    return height, width
+
+if __name__ == "__main__":
+    term_height, term_width = terminal_height_width()
+    print "The terminal has", term_height, "rows and", term_width, "columns"

--- a/IzVerifier/test/test_izverifier.py
+++ b/IzVerifier/test/test_izverifier.py
@@ -32,6 +32,7 @@ class TestVerifier(unittest.TestCase):
             'specs': ['conditions', 'strings', 'variables']
         }
         self.izv = IzVerifier(args)
+        self.izv.reporter.set_terminal_width()  # Sets width to width of terminal
 
     def test_IzPaths(self):
         """


### PR DESCRIPTION
Terminal width defaults to 80 characters, and template.format() adapts to this width or the detected width.

Note that template.format() has a larger number of arguments to adapt to terminal width.

Including self.izv.reporter.set_terminal_width() in test_izverifier.py makes these changes the default for the created instance of IzVerifier. If this line is removed, width will stay at 80 until the set_terminal_width function is called.
